### PR TITLE
Add AP_Periph MatekL431 CAN Node APD ESC status bitfield

### DIFF
--- a/Tools/AP_Periph/esc_apd_telem.cpp
+++ b/Tools/AP_Periph/esc_apd_telem.cpp
@@ -46,6 +46,10 @@ bool ESC_APD_Telem::update() {
                 // valid stop byte, check the CRC
                 if (crc_fletcher16(received.bytes, 18) == received.packet.checksum) {
                     // valid packet, copy the data we need and reset length
+                    // SKYWAYS start
+                    // There's no ESC status dronecan field, so hijacking error_count
+                    decoded.error_count = le32toh(received.packet.status_flags);
+                    // SKYWAYS end
                     decoded.voltage = le16toh(received.packet.voltage) * 1e-2f;
                     decoded.temperature = convert_temperature(le16toh(received.packet.temperature));
                     decoded.current = le16toh(received.packet.bus_current) * (1 / 12.5f);

--- a/Tools/AP_Periph/esc_apd_telem.cpp
+++ b/Tools/AP_Periph/esc_apd_telem.cpp
@@ -48,7 +48,7 @@ bool ESC_APD_Telem::update() {
                     // valid packet, copy the data we need and reset length
                     // SKYWAYS start
                     // There's no ESC status dronecan field, so hijacking error_count
-                    decoded.error_count = le32toh(received.packet.status_flags);
+                    decoded.error_count = static_cast<uint32_t>(received.packet.status_flags);
                     // SKYWAYS end
                     decoded.voltage = le16toh(received.packet.voltage) * 1e-2f;
                     decoded.temperature = convert_temperature(le16toh(received.packet.temperature));

--- a/Tools/AP_Periph/esc_apd_telem.cpp
+++ b/Tools/AP_Periph/esc_apd_telem.cpp
@@ -46,7 +46,7 @@ bool ESC_APD_Telem::update() {
                 // valid stop byte, check the CRC
                 if (crc_fletcher16(received.bytes, 18) == received.packet.checksum) {
                     // valid packet, copy the data we need and reset length
-                    // SKYWAYS start
+                    // SKYWAYS begin
                     // There's no ESC status dronecan field, so hijacking error_count
                     decoded.error_count = le32toh(received.packet.status_flags);
                     // SKYWAYS end

--- a/Tools/AP_Periph/esc_apd_telem.h
+++ b/Tools/AP_Periph/esc_apd_telem.h
@@ -40,7 +40,10 @@ private:
             uint32_t erpm;
             uint16_t input_duty;
             uint16_t motor_duty;
-            uint16_t reserved1;
+            // SKYWAYS start
+            uint8_t status_flags;
+            uint8_t reserved1;
+            // SKYWAYS end
             uint16_t checksum; // 16 bit fletcher checksum
             uint16_t stop; // should always be 65535 on a valid packet
         } packet;

--- a/Tools/AP_Periph/esc_apd_telem.h
+++ b/Tools/AP_Periph/esc_apd_telem.h
@@ -40,7 +40,7 @@ private:
             uint32_t erpm;
             uint16_t input_duty;
             uint16_t motor_duty;
-            // SKYWAYS start
+            // SKYWAYS begin
             uint8_t status_flags;
             uint8_t reserved1;
             // SKYWAYS end


### PR DESCRIPTION
This adds functionality to receive and parse APD ESC `status` , and then send via dronecan.

The dronecan `esc status` message does not have a `stutus` field.  This uses the `error count` field.